### PR TITLE
FG-BUG-01: Initialize Select Auto Complete with nested model

### DIFF
--- a/src/components/SelectAutoComplete.vue
+++ b/src/components/SelectAutoComplete.vue
@@ -45,7 +45,10 @@ export default {
   },
   data() {
     return {
-      model: {},
+      model: {
+        label: "",
+        value: "",
+      },
       options: this.$attrs.options
     };
   },

--- a/src/views/LettersIndex.vue
+++ b/src/views/LettersIndex.vue
@@ -388,6 +388,7 @@ export default {
         label: this.getFullName(id, "NN"),
         value: id,
       }));
+
       return idNameMap;
     },
 

--- a/tests/unit/views/LettersIndex.vue.spec.js
+++ b/tests/unit/views/LettersIndex.vue.spec.js
@@ -53,10 +53,11 @@ describe("LettersIndex", () => {
     wrapper.destroy();
   });
 
-  it("renders the component", async () => {
+  it("renders the component", () => {
     expect(wrapper).toBeTruthy();
   });
 
   it("filters letters by recipient when one recipient is provided", async () => {
+    
   })
 });


### PR DESCRIPTION
## Issue

After refactoring some dropdowns were showing `[Object object]`.

## What changed?

* Model initialization in `SelectAutoComplete.vue`
