### PR TITLE
BUG-02: Highlight additions in green

### DIFF
--- a/src/assets/xslt/LettersText.xslt
+++ b/src/assets/xslt/LettersText.xslt
@@ -64,7 +64,7 @@
 </xsl:template>
 
 <xsl:template match="tei:add">
-    <span class="add"> <xsl:apply-templates/> </span>
+    <span class="g-add"> <xsl:apply-templates/> </span>
 </xsl:template> 
 
 <xsl:template match="tei:del[@rendition='#s']">


### PR DESCRIPTION
## Issue

TEI additions were not highlighted as green.

## Root issue

The XSLT transformed the elements to have the class `add` instead of `g-add`.

## What changed?

The both `add` and `g-add` are now covered. The element now gets the `g-add` class.
