### PR TITLE
BUG-03: Add superscript and double underline support

### DIFF
--- a/src/assets/xslt/LettersText.xslt
+++ b/src/assets/xslt/LettersText.xslt
@@ -75,12 +75,21 @@
     <del> <xsl:apply-templates/> </del>
 </xsl:template> 
 
+
 <xsl:template match="tei:hi[@rendition='#u']">
     <u> <xsl:apply-templates/> </u>
 </xsl:template> 
 
+<xsl:template match="tei:hi[@rendition='#uu']">
+    <span class="g-uu"> <xsl:apply-templates/> </span>
+</xsl:template> 
+
 <xsl:template match="tei:hi[@rendition='#aq']">
     <span class="g-aq"> <xsl:apply-templates/> </span>
+</xsl:template> 
+
+<xsl:template match="tei:hi[@rendition='#sup']">
+    <sup> <xsl:apply-templates/> </sup>
 </xsl:template> 
 
 <xsl:template match="tei:ex">

--- a/src/components/LettersText.vue
+++ b/src/components/LettersText.vue
@@ -92,9 +92,12 @@ export default {
 span.g-add
   color: green
 
-
 del
   color: red
+
+.g-uu
+  text-decoration-line: underline
+  text-decoration-style: double
 
 .g-entity-link
   box-shadow: inset 0 -0.7rem 0 0 hsla(144.9, 100%, 82.5%, 0.5)


### PR DESCRIPTION
## Issue

TEI elements with superscript or double underline rendition were not displayed as such.

## What changed?

The LettersText XSLT now contians support for those elements.
