### PR TITLE
FG-03-11-1: Show person role

### DIFF
--- a/src/services/person-service.js
+++ b/src/services/person-service.js
@@ -5,10 +5,44 @@ export const getPersonRoleTranslation = role => {
     case "fictional":
       return "Fiktionale Person";
     default:
-      return "Reale Person";
+      return "Person";
+  }
+};
+
+export const getPersonRoleClass = role => {
+  switch (role) {
+    case "mythological":
+      return "purple-1";
+    case "fictional":
+      return "cyan-1";
+    default:
+      return "orange-1";
+  }
+};
+
+export const getPersonTypeTranslation = personType => {
+  switch (personType) {
+    case "organisation":
+      return "Organisation";
+    case "person":
+    default:
+      return "Person";
+  }
+};
+
+export const getPersonTypeClass = personType => {
+  switch (personType) {
+    case "organisation":
+      return "blue-1";
+    case "person":
+    default:
+      return "orange-1";
   }
 };
 
 export default {
-  getPersonRoleTranslation
+  getPersonRoleTranslation,
+  getPersonRoleClass,
+  getPersonTypeTranslation,
+  getPersonTypeClass
 };

--- a/src/services/person-service.js
+++ b/src/services/person-service.js
@@ -23,7 +23,8 @@ export const getPersonRoleClass = role => {
 export const getPersonTypeTranslation = personType => {
   switch (personType) {
     case "organisation":
-      return "Organisation";
+    case "org":
+      return "Körperschaft";
     case "person":
     default:
       return "Person";
@@ -33,6 +34,7 @@ export const getPersonTypeTranslation = personType => {
 export const getPersonTypeClass = personType => {
   switch (personType) {
     case "organisation":
+    case "org":
       return "blue-1";
     case "person":
     default:

--- a/src/services/person-service.js
+++ b/src/services/person-service.js
@@ -1,0 +1,14 @@
+export const getPersonRoleTranslation = role => {
+  switch (role) {
+    case "mythological":
+      return "Mythologische Figur";
+    case "fictional":
+      return "Fiktionale Person";
+    default:
+      return "Reale Person";
+  }
+};
+
+export default {
+  getPersonRoleTranslation
+};

--- a/src/views/PersonsDetail.vue
+++ b/src/views/PersonsDetail.vue
@@ -14,8 +14,11 @@
               </div>
             </q-card-section>
             <q-card-section>
-              <q-chip v-if="roleName" id="role" :color="roleClass">
+              <q-chip v-if="roleName && isPerson" id="role" :color="roleClass">
                 {{ roleName }}
+              </q-chip>
+              <q-chip v-if="isOrganisation" id="role" color="blue-1">
+                Körperschaft
               </q-chip>
               <a v-if="data.person.idno" :href="authorityUri">
                 <q-chip color="blue-1" class="q-ml-none">
@@ -97,6 +100,12 @@ export default {
         return {};
       }
       return this.persons.find(person => person.id === this.entityId).properties;
+    },
+    isPerson() {
+      return this.properties.type === "person";
+    },
+    isOrganisation() {
+      return this.properties.type === "org";
     },
     roleName() {
       if (!this.persons.length) {

--- a/src/views/PersonsDetail.vue
+++ b/src/views/PersonsDetail.vue
@@ -33,11 +33,7 @@
       </div>
       <div class="row justify-center">
         <div class="col-md-8 col-12 q-pb-xl q-gutter-y-lg">
-          <MentionsTable
-            :entity-id="this.$route.params.id"
-            :entity-name="name"
-            entity-type="persons"
-          />
+          <MentionsTable :entity-id="entityId" :entity-name="name" entity-type="persons" />
         </div>
       </div>
     </q-page>
@@ -54,9 +50,18 @@ import { mapActions } from "vuex";
 import MentionsTable from "@/components/MentionsTable";
 import { dataService } from "@/shared";
 
+import { QCard, QCardSection, QPage, QSeparator, QSpinnerOval } from "quasar";
+
 export default {
   name: "PersonsDetail",
-  components: { MentionsTable },
+  components: {
+    QCard,
+    QCardSection,
+    QPage,
+    QSeparator,
+    QSpinnerOval,
+    MentionsTable
+  },
   data() {
     return {
       data: {
@@ -72,6 +77,9 @@ export default {
   },
 
   computed: {
+    entityId() {
+      return this.$route.params.id;
+    },
     name() {
       return this.$store.getters.fullNameIndex[this.$route.params.id];
     },

--- a/src/views/PersonsDetail.vue
+++ b/src/views/PersonsDetail.vue
@@ -14,18 +14,19 @@
               </div>
             </q-card-section>
             <q-card-section>
-              <div v-if="data.person.idno">
-                <a :href="authorityUri">
-                  <q-chip color="blue-1" class="q-ml-none">
-                    <q-avatar rounded font-size="11px" color="blue-5" class="text-white">
-                      GND
-                    </q-avatar>
-                    <div class="text-blue text-caption q-pl-sm">
-                      {{ authorityUri }}
-                    </div>
-                  </q-chip>
-                </a>
-              </div>
+              <q-chip v-if="roleName" id="role" :color="roleClass">
+                {{ roleName }}
+              </q-chip>
+              <a v-if="data.person.idno" :href="authorityUri">
+                <q-chip color="blue-1" class="q-ml-none">
+                  <q-avatar rounded font-size="11px" color="blue-5" class="text-white">
+                    GND
+                  </q-avatar>
+                  <div class="text-blue text-caption q-pl-sm">
+                    {{ authorityUri }}
+                  </div>
+                </q-chip>
+              </a>
             </q-card-section>
             <q-separator dark />
           </q-card>
@@ -46,17 +47,19 @@
 </template>
 
 <script>
-import { mapActions } from "vuex";
+import { mapActions, mapGetters } from "vuex";
 import MentionsTable from "@/components/MentionsTable";
 import { dataService } from "@/shared";
+import personService from "@/services/person-service";
 
-import { QCard, QCardSection, QPage, QSeparator, QSpinnerOval } from "quasar";
+import { QCard, QCardSection, QChip, QPage, QSeparator, QSpinnerOval } from "quasar";
 
 export default {
   name: "PersonsDetail",
   components: {
     QCard,
     QCardSection,
+    QChip,
     QPage,
     QSeparator,
     QSpinnerOval,
@@ -77,16 +80,32 @@ export default {
   },
 
   computed: {
+    ...mapGetters(["fullNameIndex", "persons"]),
     entityId() {
       return this.$route.params.id;
     },
     name() {
-      return this.$store.getters.fullNameIndex[this.$route.params.id];
+      return this.fullNameIndex[this.$route.params.id];
     },
     authorityUri() {
       return this.data.person.idno.length > 1
         ? this.data.person.idno[0]["#text"]
         : this.data.person.idno["#text"];
+    },
+    properties() {
+      if (!this.persons.length) {
+        return {};
+      }
+      return this.persons.find(person => person.id === this.entityId).properties;
+    },
+    roleName() {
+      if (!this.persons.length) {
+        return "";
+      }
+      return personService.getPersonRoleTranslation(this.properties.role);
+    },
+    roleClass() {
+      return personService.getPersonRoleClass(this.properties.role);
     }
   },
 

--- a/src/views/PersonsIndex.vue
+++ b/src/views/PersonsIndex.vue
@@ -32,10 +32,18 @@
                     <q-item-label>{{ props.row.properties.name.fullName }}</q-item-label>
                   </q-item-section>
                   <q-chip
+                    v-if="isOrganisation(props.row.properties.type)"
                     size="12px"
-                    :color="props.row.properties.type === 'org' ? 'blue-1' : 'orange-1'"
+                    color="blue-1"
                   >
                     {{ props.row.properties.type | formatPersonType }}
+                  </q-chip>
+                  <q-chip
+                    v-if="isPerson(props.row.properties.type)"
+                    size="12px"
+                    :color="getRoleClass(props.row.properties.role)"
+                  >
+                    {{ props.row.properties.role | formatPersonRole }}
                   </q-chip>
                 </q-item>
               </q-list>
@@ -48,17 +56,23 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
+import { QPage, QTable } from "quasar";
+
+import personService from "@/services/person-service";
+
 export default {
   name: "PersonsIndex",
+  components: {
+    QPage,
+    QTable
+  },
   filters: {
     formatPersonType(rawType) {
-      if (rawType === "org") {
-        return "Körperschaft";
-      }
-      if (rawType === "person") {
-        return "Person";
-      }
-      return rawType;
+      return personService.getPersonTypeTranslation(rawType);
+    },
+    formatPersonRole(rawRole) {
+      return personService.getPersonRoleTranslation(rawRole);
     }
   },
 
@@ -92,10 +106,21 @@ export default {
       return this.$store.getters.persons;
     }
   },
-
   async mounted() {
-    await this.$store.dispatch("loadFullNameIndexAction");
+    await this.loadFullNameIndexAction();
     this.loading = false;
+  },
+  methods: {
+    ...mapActions(["loadFullNameIndexAction"]),
+    isPerson(rawType) {
+      return rawType === "person";
+    },
+    isOrganisation(rawType) {
+      return rawType === "org";
+    },
+    getRoleClass(rawRole) {
+      return personService.getPersonRoleClass(rawRole);
+    }
   }
 };
 </script>

--- a/tests/unit/fixtures/persons.js
+++ b/tests/unit/fixtures/persons.js
@@ -4,12 +4,12 @@ export const persons = [
     entity: "persons",
     properties: {
       type: "person",
+      role: null,
       name: {
         surname: "Caesar",
         forename: "Gaius Julius",
         simpleName: null,
         roleName: null,
-        role: null,
         orgName: null,
         fullName: "Caesar, Gaius Julius"
       }
@@ -20,12 +20,12 @@ export const persons = [
     entity: "persons",
     properties: {
       type: "person",
+      role: "mythological",
       name: {
         surname: null,
         forename: null,
         simpleName: "Jupiter",
         roleName: null,
-        role: "mythological",
         orgName: null,
         fullName: "Jupiter"
       }
@@ -36,12 +36,12 @@ export const persons = [
     entity: "persons",
     properties: {
       type: "person",
+      role: "fictional",
       name: {
         surname: null,
         forename: null,
         simpleName: "Sindbad",
         roleName: null,
-        role: "fictional",
         orgName: null,
         fullName: "Sindbad"
       }

--- a/tests/unit/fixtures/persons.js
+++ b/tests/unit/fixtures/persons.js
@@ -1,0 +1,50 @@
+export const persons = [
+  {
+    id: "ed_cqw_yc5_plb",
+    entity: "persons",
+    properties: {
+      type: "person",
+      name: {
+        surname: "Caesar",
+        forename: "Gaius Julius",
+        simpleName: null,
+        roleName: null,
+        role: null,
+        orgName: null,
+        fullName: "Caesar, Gaius Julius"
+      }
+    }
+  },
+  {
+    id: "G001323",
+    entity: "persons",
+    properties: {
+      type: "person",
+      name: {
+        surname: null,
+        forename: null,
+        simpleName: "Jupiter",
+        roleName: null,
+        role: "mythological",
+        orgName: null,
+        fullName: "Jupiter"
+      }
+    }
+  },
+  {
+    id: "G001606",
+    entity: "persons",
+    properties: {
+      type: "person",
+      name: {
+        surname: null,
+        forename: null,
+        simpleName: "Sindbad",
+        roleName: null,
+        role: "fictional",
+        orgName: null,
+        fullName: "Sindbad"
+      }
+    }
+  }
+];

--- a/tests/unit/fixtures/persons.js
+++ b/tests/unit/fixtures/persons.js
@@ -46,5 +46,21 @@ export const persons = [
         fullName: "Sindbad"
       }
     }
+  },
+  {
+    id: "ed_mg4_mp5_5lb",
+    entity: "persons",
+    properties: {
+      type: "org",
+      role: null,
+      name: {
+        surname: null,
+        forename: null,
+        simpleName: null,
+        roleName: null,
+        orgName: "Acta Sanctorum",
+        fullName: "Acta Sanctorum"
+      }
+    }
   }
 ];

--- a/tests/unit/services/person-service.spec.js
+++ b/tests/unit/services/person-service.spec.js
@@ -19,7 +19,8 @@ describe("PersonService", () => {
     expect(personService.getPersonTypeTranslation(null)).toBe("Person");
     expect(personService.getPersonTypeTranslation("")).toBe("Person");
     expect(personService.getPersonTypeTranslation("person")).toBe("Person");
-    expect(personService.getPersonTypeTranslation("organisation")).toBe("Organisation");
+    expect(personService.getPersonTypeTranslation("organisation")).toBe("Körperschaft");
+    expect(personService.getPersonTypeTranslation("org")).toBe("Körperschaft");
   });
 
   it("gets the color class depending on the person type", () => {
@@ -27,5 +28,6 @@ describe("PersonService", () => {
     expect(personService.getPersonTypeClass("")).toBe("orange-1");
     expect(personService.getPersonTypeClass("person")).toBe("orange-1");
     expect(personService.getPersonTypeClass("organisation")).toBe("blue-1");
+    expect(personService.getPersonTypeClass("org")).toBe("blue-1");
   });
 });

--- a/tests/unit/services/person-service.spec.js
+++ b/tests/unit/services/person-service.spec.js
@@ -2,9 +2,30 @@ import personService from "@/services/person-service";
 
 describe("PersonService", () => {
   it("translates the role types", () => {
-    expect(personService.getPersonRoleTranslation(null)).toBe("Reale Person");
-    expect(personService.getPersonRoleTranslation("")).toBe("Reale Person");
+    expect(personService.getPersonRoleTranslation(null)).toBe("Person");
+    expect(personService.getPersonRoleTranslation("")).toBe("Person");
     expect(personService.getPersonRoleTranslation("mythological")).toBe("Mythologische Figur");
     expect(personService.getPersonRoleTranslation("fictional")).toBe("Fiktionale Person");
+  });
+
+  it("gets the color class depending on the role", () => {
+    expect(personService.getPersonRoleClass(null)).toBe("orange-1");
+    expect(personService.getPersonRoleClass("")).toBe("orange-1");
+    expect(personService.getPersonRoleClass("mythological")).toBe("purple-1");
+    expect(personService.getPersonRoleClass("fictional")).toBe("cyan-1");
+  });
+
+  it("tranlsates the person types", () => {
+    expect(personService.getPersonTypeTranslation(null)).toBe("Person");
+    expect(personService.getPersonTypeTranslation("")).toBe("Person");
+    expect(personService.getPersonTypeTranslation("person")).toBe("Person");
+    expect(personService.getPersonTypeTranslation("organisation")).toBe("Organisation");
+  });
+
+  it("gets the color class depending on the person type", () => {
+    expect(personService.getPersonTypeClass(null)).toBe("orange-1");
+    expect(personService.getPersonTypeClass("")).toBe("orange-1");
+    expect(personService.getPersonTypeClass("person")).toBe("orange-1");
+    expect(personService.getPersonTypeClass("organisation")).toBe("blue-1");
   });
 });

--- a/tests/unit/services/person-service.spec.js
+++ b/tests/unit/services/person-service.spec.js
@@ -1,0 +1,10 @@
+import personService from "@/services/person-service";
+
+describe("PersonService", () => {
+  it("translates the role types", () => {
+    expect(personService.getPersonRoleTranslation(null)).toBe("Reale Person");
+    expect(personService.getPersonRoleTranslation("")).toBe("Reale Person");
+    expect(personService.getPersonRoleTranslation("mythological")).toBe("Mythologische Figur");
+    expect(personService.getPersonRoleTranslation("fictional")).toBe("Fiktionale Person");
+  });
+});

--- a/tests/unit/views/PersonsDetail.vue.spec.js
+++ b/tests/unit/views/PersonsDetail.vue.spec.js
@@ -69,7 +69,7 @@ describe("PersonsDetail view", () => {
     wrapper.destroy();
   });
 
-  it("displays the role element", () => {
+  it("displays the role element when the entry is a person and not an organisation", () => {
     wrapper = shallowMount(PersonsDetail, {
       localVue,
       store,
@@ -84,6 +84,8 @@ describe("PersonsDetail view", () => {
     const targetRole = "Mythologische Figur";
 
     expect(wrapper.vm.roleName).toBe(targetRole);
+    expect(wrapper.vm.isPerson).toBeTruthy();
+    expect(wrapper.vm.isOrganisation).toBeFalsy();
     expect(roleElement.exists()).toBeTruthy();
     expect(roleElement.text()).toBe(targetRole);
 

--- a/tests/unit/views/PersonsDetail.vue.spec.js
+++ b/tests/unit/views/PersonsDetail.vue.spec.js
@@ -52,4 +52,41 @@ describe("PersonsDetail view", () => {
 
     wrapper.destroy();
   });
+
+  it("can get the person properties", () => {
+    wrapper = shallowMount(PersonsDetail, {
+      localVue,
+      store,
+      router,
+      computed: {
+        entityId: () => "G001323"
+      }
+    });
+    wrapper.vm.getItems = jest.fn();
+
+    expect(wrapper.vm.properties.role).toBe("mythological");
+
+    wrapper.destroy();
+  });
+
+  it("displays the role element", () => {
+    wrapper = shallowMount(PersonsDetail, {
+      localVue,
+      store,
+      router,
+      computed: {
+        entityId: () => "G001323"
+      }
+    });
+    wrapper.vm.getItems = jest.fn();
+
+    const roleElement = wrapper.find("#role");
+    const targetRole = "Mythologische Figur";
+
+    expect(wrapper.vm.roleName).toBe(targetRole);
+    expect(roleElement.exists()).toBeTruthy();
+    expect(roleElement.text()).toBe(targetRole);
+
+    wrapper.destroy();
+  });
 });

--- a/tests/unit/views/PersonsDetail.vue.spec.js
+++ b/tests/unit/views/PersonsDetail.vue.spec.js
@@ -1,0 +1,55 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import * as Vuex from "vuex";
+import VueRouter from "vue-router";
+import { routes } from "@/router";
+
+import PersonsDetail from "@/views/PersonsDetail.vue";
+import { persons } from "../fixtures/persons";
+
+describe("PersonsDetail view", () => {
+  let wrapper;
+  let localVue;
+  let actions;
+  let getters;
+  let store;
+
+  jest.doMock("axios", () => ({
+    get: jest.fn()
+  }));
+
+  localVue = createLocalVue();
+  localVue.use(Vuex);
+  const router = new VueRouter({ routes, mode: "abstract" });
+
+  beforeEach(() => {
+    getters = {
+      fullNameIndex: () => [],
+      persons: () => persons
+    };
+
+    actions = {
+      loadFullNameIndexAction: jest.fn()
+    };
+
+    store = new Vuex.Store({
+      actions,
+      getters
+    });
+  });
+
+  it("creates the component", () => {
+    wrapper = shallowMount(PersonsDetail, {
+      localVue,
+      store,
+      router,
+      computed: {
+        entityId: () => "G001323"
+      }
+    });
+    wrapper.vm.getItems = jest.fn();
+
+    expect(wrapper).toBeTruthy();
+
+    wrapper.destroy();
+  });
+});

--- a/tests/unit/views/PersonsIndex.vue.spec.js
+++ b/tests/unit/views/PersonsIndex.vue.spec.js
@@ -1,0 +1,53 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import * as Vuex from "vuex";
+import VueRouter from "vue-router";
+import { routes } from "@/router";
+
+import { persons } from "../fixtures/persons";
+
+import PersonsIndex from "@/views/PersonsIndex.vue";
+
+describe("PersonsIndex component", () => {
+  let wrapper;
+  let localVue;
+  let actions;
+  let getters;
+  let store;
+
+  jest.doMock("axios", () => ({
+    get: jest.fn()
+  }));
+
+  localVue = createLocalVue();
+  localVue.use(Vuex);
+  const router = new VueRouter({ routes, mode: "abstract" });
+
+  beforeEach(() => {
+    getters = {
+      fullNameIndex: () => [],
+      persons: () => persons
+    };
+
+    actions = {
+      loadFullNameIndexAction: jest.fn()
+    };
+
+    store = new Vuex.Store({
+      actions,
+      getters
+    });
+  });
+
+  it("creates the component", () => {
+    wrapper = shallowMount(PersonsIndex, {
+      localVue,
+      store,
+      router
+    });
+    wrapper.vm.getItems = jest.fn();
+
+    expect(wrapper).toBeTruthy();
+
+    wrapper.destroy();
+  });
+});


### PR DESCRIPTION
## Issue

We want to distinguish between natural persons, organisations, fictional characters and mythological figures.

## What changed?

* The PersonsDetail view now shows a chip containing the person type and/or role
* The PersonsIndex view now also lists this status