### PR TITLE
FG-03-11-2: Add support for alternative person names

### DIFF
--- a/src/services/person-service.js
+++ b/src/services/person-service.js
@@ -42,9 +42,57 @@ export const getPersonTypeClass = personType => {
   }
 };
 
+export const getPersonAlternativeNameTypeTranslation = subType => {
+  switch (subType) {
+    case "birthname":
+      return "Geburtsname";
+    case "pseudonym":
+      return "Pseudonym";
+    default:
+      return "Alternativ";
+  }
+};
+
+export const hasDifferentSimpleName = person => {
+  if (!person.properties.name.simpleName) {
+    return false;
+  }
+  return person.properties.name.fullName !== person.properties.name.simpleName;
+};
+
+export const hasAlternativeName = person => {
+  return (
+    person.properties.name.altForename ||
+    person.properties.name.altSurname ||
+    person.properties.name.altSimpleName
+  );
+};
+
+export const getAlternativeFullName = person => {
+  let name = "";
+
+  if (person.properties.name.altSurname) {
+    name += person.properties.name.altSurname;
+  }
+
+  if (person.properties.name.altSurname && person.properties.name.altForename) {
+    name += ", ";
+  }
+
+  if (person.properties.name.altForename) {
+    name += person.properties.name.altForename;
+  }
+
+  return name;
+};
+
 export default {
   getPersonRoleTranslation,
   getPersonRoleClass,
   getPersonTypeTranslation,
-  getPersonTypeClass
+  getPersonTypeClass,
+  hasDifferentSimpleName,
+  hasAlternativeName,
+  getAlternativeFullName,
+  getPersonAlternativeNameTypeTranslation
 };

--- a/src/views/PersonsDetail.vue
+++ b/src/views/PersonsDetail.vue
@@ -12,6 +12,17 @@
               >
                 {{ data.person.birth }} – {{ data.person.death }}
               </div>
+              <div v-if="hasAlternativeName" class="text-caption q-tm-sm text-secondary">
+                <span>
+                  <span class="text-weight-bold">{{ alternativeNameType }}:</span>
+                </span>
+                <span v-if="alternativeFullName">
+                  {{ alternativeFullName }}
+                </span>
+                <span v-if="alternativeSimpleName">
+                  {{ alternativeSimpleName }}
+                </span>
+              </div>
             </q-card-section>
             <q-card-section>
               <q-chip v-if="roleName && isPerson" id="role" :color="roleClass">
@@ -95,11 +106,17 @@ export default {
         ? this.data.person.idno[0]["#text"]
         : this.data.person.idno["#text"];
     },
+    entity() {
+      if (!this.persons.length) {
+        return {};
+      }
+      return this.persons.find(person => person.id === this.entityId);
+    },
     properties() {
       if (!this.persons.length) {
         return {};
       }
-      return this.persons.find(person => person.id === this.entityId).properties;
+      return this.entity.properties;
     },
     isPerson() {
       return this.properties.type === "person";
@@ -115,6 +132,23 @@ export default {
     },
     roleClass() {
       return personService.getPersonRoleClass(this.properties.role);
+    },
+    alternativeNameType() {
+      return personService.getPersonAlternativeNameTypeTranslation(
+        this.properties.name.altNameType
+      );
+    },
+    hasAlternativeName() {
+      if (!this.persons.length) {
+        return false;
+      }
+      return personService.hasAlternativeName(this.entity);
+    },
+    alternativeFullName() {
+      return personService.getAlternativeFullName(this.entity);
+    },
+    alternativeSimpleName() {
+      return this.properties.name.altSimpleName;
     }
   },
 

--- a/src/views/PersonsIndex.vue
+++ b/src/views/PersonsIndex.vue
@@ -30,6 +30,30 @@
                 >
                   <q-item-section>
                     <q-item-label>{{ props.row.properties.name.fullName }}</q-item-label>
+                    <div
+                      v-if="hasDifferentSimpleName(props.row)"
+                      class="text-subtitle3 text-secondary"
+                    >
+                      {{ props.row.properties.name.simpleName }}
+                    </div>
+                    <div
+                      v-if="hasAlternativeName(props.row)"
+                      class="text-caption q-tm-sm text-secondary"
+                    >
+                      <span>
+                        <span class="text-weight-bold"
+                          >{{
+                            props.row.properties.name.altNameSubtype | formatAlternativeNameSubType
+                          }}:</span
+                        >
+                      </span>
+                      <span v-if="getAlternativeFullName(props.row)">
+                        {{ getAlternativeFullName(props.row) }}
+                      </span>
+                      <span v-if="props.row.properties.name.altSimpleName">
+                        {{ props.row.properties.name.altSimpleName }}
+                      </span>
+                    </div>
                   </q-item-section>
                   <q-chip
                     v-if="isOrganisation(props.row.properties.type)"
@@ -73,6 +97,9 @@ export default {
     },
     formatPersonRole(rawRole) {
       return personService.getPersonRoleTranslation(rawRole);
+    },
+    formatAlternativeNameSubType(subType) {
+      return personService.getPersonAlternativeNameTypeTranslation(subType);
     }
   },
 
@@ -90,10 +117,21 @@ export default {
           required: true,
           label: "Name",
           align: "left",
-          field: row =>
-            row.properties.name.orgName ||
-            row.properties.name.simpleName ||
-            row.properties.name.surname,
+          field: row => {
+            return [
+              row.properties.name.surname,
+              row.properties.name.forename,
+              row.properties.name.simpleName,
+              row.properties.name.roleName,
+              row.properties.name.orgName,
+              row.properties.name.fullName,
+              row.properties.name.altSurname,
+              row.properties.name.altForename,
+              row.properties.name.altSimpleName
+            ]
+              .filter(content => content)
+              .join(" ");
+          },
           sortable: true
         }
       ],
@@ -120,6 +158,15 @@ export default {
     },
     getRoleClass(rawRole) {
       return personService.getPersonRoleClass(rawRole);
+    },
+    hasDifferentSimpleName(row) {
+      return personService.hasDifferentSimpleName(row);
+    },
+    hasAlternativeName(row) {
+      return personService.hasAlternativeName(row);
+    },
+    getAlternativeFullName(row) {
+      return personService.getAlternativeFullName(row);
     }
   }
 };

--- a/src/views/PersonsIndex.vue
+++ b/src/views/PersonsIndex.vue
@@ -30,12 +30,14 @@
                 >
                   <q-item-section>
                     <q-item-label>{{ props.row.properties.name.fullName }}</q-item-label>
+                    <!--
                     <div
                       v-if="hasDifferentSimpleName(props.row)"
                       class="text-subtitle3 text-secondary"
                     >
                       {{ props.row.properties.name.simpleName }}
                     </div>
+                    -->
                     <div
                       v-if="hasAlternativeName(props.row)"
                       class="text-caption q-tm-sm text-secondary"
@@ -54,6 +56,17 @@
                         {{ props.row.properties.name.altSimpleName }}
                       </span>
                     </div>
+                    <!--
+                    <div
+                      v-if="props.row.properties.name.roleName"
+                      class="text-caption q-tm-sm text-secondary"
+                    >
+                      <span class="text-weight-bold">
+                        Rolle:
+                      </span>
+                      {{ props.row.properties.name.roleName }}
+                    </div>
+                    -->
                   </q-item-section>
                   <q-chip
                     v-if="isOrganisation(props.row.properties.type)"

--- a/tests/unit/fixtures/persons.js
+++ b/tests/unit/fixtures/persons.js
@@ -11,7 +11,11 @@ export const persons = [
         simpleName: null,
         roleName: null,
         orgName: null,
-        fullName: "Caesar, Gaius Julius"
+        fullName: "Caesar, Gaius Julius",
+        altNameSubtype: null,
+        altSurname: null,
+        altForename: null,
+        altSimpleName: null
       }
     }
   },
@@ -27,7 +31,11 @@ export const persons = [
         simpleName: "Jupiter",
         roleName: null,
         orgName: null,
-        fullName: "Jupiter"
+        fullName: "Jupiter",
+        altNameSubtype: null,
+        altSurname: null,
+        altForename: null,
+        altSimpleName: null
       }
     }
   },
@@ -43,7 +51,11 @@ export const persons = [
         simpleName: "Sindbad",
         roleName: null,
         orgName: null,
-        fullName: "Sindbad"
+        fullName: "Sindbad",
+        altNameSubtype: null,
+        altSurname: null,
+        altForename: null,
+        altSimpleName: null
       }
     }
   },
@@ -59,7 +71,51 @@ export const persons = [
         simpleName: null,
         roleName: null,
         orgName: "Acta Sanctorum",
-        fullName: "Acta Sanctorum"
+        fullName: "Acta Sanctorum",
+        altNameSubtype: null,
+        altSurname: null,
+        altForename: null,
+        altSimpleName: null
+      }
+    }
+  },
+  {
+    id: "ed_mym_3bz_z4b",
+    entity: "persons",
+    properties: {
+      type: "person",
+      role: null,
+      name: {
+        surname: null,
+        forename: null,
+        simpleName: "Abd el-Kader",
+        roleName: "Emir",
+        orgName: null,
+        fullName: "Abd el-Kader, Emir",
+        altNameSubtype: null,
+        altSurname: null,
+        altForename: null,
+        altSimpleName: null
+      }
+    }
+  },
+  {
+    id: "G001274",
+    entity: "persons",
+    properties: {
+      type: "person",
+      role: null,
+      name: {
+        surname: "Heyse",
+        forename: "Paul",
+        simpleName: null,
+        roleName: null,
+        orgName: null,
+        fullName: "Heyse, Paul",
+        altNameSubtype: "pseudonym",
+        altSurname: "Florentin",
+        altForename: "Theodor",
+        altSimpleName: null
       }
     }
   }

--- a/tests/unit/services/person-service.spec.js
+++ b/tests/unit/services/person-service.spec.js
@@ -1,4 +1,5 @@
 import personService from "@/services/person-service";
+import { persons } from "../fixtures/persons";
 
 describe("PersonService", () => {
   it("translates the role types", () => {
@@ -29,5 +30,61 @@ describe("PersonService", () => {
     expect(personService.getPersonTypeClass("person")).toBe("orange-1");
     expect(personService.getPersonTypeClass("organisation")).toBe("blue-1");
     expect(personService.getPersonTypeClass("org")).toBe("blue-1");
+  });
+
+  it("translates the alternative name subtype", () => {
+    expect(personService.getPersonAlternativeNameTypeTranslation(null)).toBe("Alternativ");
+    expect(personService.getPersonAlternativeNameTypeTranslation("")).toBe("Alternativ");
+    expect(personService.getPersonAlternativeNameTypeTranslation("birthname")).toBe("Geburtsname");
+    expect(personService.getPersonAlternativeNameTypeTranslation("pseudonym")).toBe("Pseudonym");
+  });
+
+  it("checks whether there an entry has a differing simple name", () => {
+    // Sindbad entry
+    const sindbad = persons[2];
+    sindbad.properties.name.fullName = "Sindbad";
+    sindbad.properties.name.simpleName = "Sindbad";
+    expect(personService.hasDifferentSimpleName(sindbad)).toBeFalsy();
+
+    // Null entry
+    const nullEntry = persons[2];
+    sindbad.properties.name.fullName = "Sindbad";
+    sindbad.properties.name.simpleName = null;
+    expect(personService.hasDifferentSimpleName(nullEntry)).toBeFalsy();
+
+    // Differing entry
+    const differingEntry = persons[2];
+    sindbad.properties.name.fullName = "Sindbad";
+    sindbad.properties.name.simpleName = "Cindy";
+    expect(personService.hasDifferentSimpleName(differingEntry)).toBeTruthy();
+  });
+
+  it("gets an alternative name, if there is one", () => {
+    const noAltName = persons[0];
+    noAltName.properties.name.altSurname = null;
+    noAltName.properties.name.altForename = null;
+    noAltName.properties.name.altSimpleName = null;
+    expect(personService.hasAlternativeName(noAltName)).toBeFalsy();
+
+    const altNameExample = persons[5];
+    altNameExample.properties.name.altSurname = "Florentin";
+    altNameExample.properties.name.altForename = "Theodor";
+
+    expect(personService.hasAlternativeName(altNameExample)).toBeTruthy();
+    expect(personService.getAlternativeFullName(altNameExample)).toBe("Florentin, Theodor");
+
+    const altNameSurnameExample = persons[5];
+    altNameSurnameExample.properties.name.altSurname = "Florentin";
+    altNameSurnameExample.properties.name.altForename = null;
+
+    expect(personService.hasAlternativeName(altNameExample)).toBeTruthy();
+    expect(personService.getAlternativeFullName(altNameExample)).toBe("Florentin");
+
+    const altNameForenameExample = persons[5];
+    altNameForenameExample.properties.name.altSurname = null;
+    altNameForenameExample.properties.name.altForename = "Theodor";
+
+    expect(personService.hasAlternativeName(altNameExample)).toBeTruthy();
+    expect(personService.getAlternativeFullName(altNameExample)).toBe("Theodor");
   });
 });


### PR DESCRIPTION
## Issue

We want to see alternative names, if available, on the PersonsDetail and PersonsIndex view. Additionally, we want to be able to search for first names, roles, alternative names etc. in the Person Index view.

## What changed?

* When available, alternative names are displayed on the PersonsDetail and PersonsIndex view.
* The filter in the PersonsIndex view now supports all the fields of a person entity entry.