### PR TITLE
BUG-08: Comment reset and loading checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gregorovius-frontend",
-  "version": "1.7.0-beta",
+  "version": "1.7.1-beta",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/MentionsTile.vue
+++ b/src/components/MentionsTile.vue
@@ -88,7 +88,7 @@ export default {
         return "";
       }
 
-      if (this.entity.properties.birth.length && this.entity.properties.death.length) {
+      if (this.entity.properties.birth && this.entity.properties.death) {
         return `${this.entity.properties.birth} – ${this.entity.properties.death}`;
       }
 

--- a/src/services/letter-service.js
+++ b/src/services/letter-service.js
@@ -83,6 +83,9 @@ const getEditorName = editor => {
 };
 
 const getCitationRecommendation = data => {
+  if (!data.teiHeader) {
+    return "";
+  }
   const title = getTitle(data);
   const secondaryTitle = getSecondaryTitle(data);
   const editor = getEditor(data);

--- a/src/views/LettersDetail.vue
+++ b/src/views/LettersDetail.vue
@@ -597,7 +597,8 @@ export default {
       }
     },
     async openPreviousLetter() {
-      this.$router.push({
+      await this.$store.dispatch("unselectComment");
+      await this.$router.push({
         name: "Brief",
         params: {
           id: this.previousLetter.id
@@ -605,7 +606,8 @@ export default {
       });
     },
     async openNextLetter() {
-      this.$router.push({
+      await this.$store.dispatch("unselectComment");
+      await this.$router.push({
         name: "Brief",
         params: {
           id: this.nextLetter.id
@@ -613,7 +615,8 @@ export default {
       });
     },
     async openPreviousLetterInSelection() {
-      this.$router.push({
+      await this.$store.dispatch("unselectComment");
+      await this.$router.push({
         name: "Brief",
         params: {
           id: this.previousLetterInSelection.id
@@ -621,7 +624,8 @@ export default {
       });
     },
     async openNextLetterInSelection() {
-      this.$router.push({
+      await this.$store.dispatch("unselectComment");
+      await this.$router.push({
         name: "Brief",
         params: {
           id: this.nextLetterInSelection.id


### PR DESCRIPTION
## Issue

When browsing in letters while having a text comment open, the comment would remain after changing the letter. This PR addresses that.

Additionally, some load time dependent errors have been fixed.