### PR TITLE
SUPPORT-26: Apply selected years to store after refactoring

### DIFF
--- a/src/components/SelectYears.vue
+++ b/src/components/SelectYears.vue
@@ -60,7 +60,7 @@ export default {
     }
   },
   watch: {
-    model: {
+    selectedYears: {
       handler: function(newValue) {
         this.setSelectedAction({ entity: "years", value: newValue });
       }


### PR DESCRIPTION
## Issue

After a recent refactoring, the selected years filter was not applied to the list of letters / search results.

## What changed?

- Watcher reference

