### PR TITLE
DHI-GREG-FE-68: Open letter in new tab from letter index

### DIFF
--- a/src/components/LettersFullIndexEntry.vue
+++ b/src/components/LettersFullIndexEntry.vue
@@ -10,7 +10,9 @@
             color="primary"
             label="Brief öffnen"
             @click="$router.push({ name: 'Brief', params: { id: entry.xml_id } })"
-          />
+          >
+            <context-menu :route-to-open="$router.resolve({ name: 'Brief', params: { id: entry.xml_id } }).href"/>
+          </q-btn>
           <q-icon
             :name="entry.status === 'ED' ? 'check_circle' : 'cancel'"
             :color="entry.status === 'ED' ? 'primary' : 'red'"
@@ -119,6 +121,7 @@
 import { QMenu, QBtn, QChip, QAvatar } from "quasar";
 import LettersFullIndexEntryPersonContextMenu
   from "@/components/LettersFullIndexEntryPersonContextMenu.vue";
+import ContextMenu from "@/components/ContextMenu.vue";
 export default {
   name: "LettersFullIndexEntry",
   components: {
@@ -126,7 +129,8 @@ export default {
     QAvatar,
     QChip,
     QMenu,
-    QBtn
+    QBtn,
+    ContextMenu,
   },
   props: {
     entry: {


### PR DESCRIPTION
## Issue

We want to be able to open letters in a new tab in the letter index.

## How to test?

- Go to `/letters/full-index`
- Right click on an edited letter "BRIEF ÖFFNEN"
- A context menu should appear
